### PR TITLE
Implement Container Image Syncer

### DIFF
--- a/.github/workflows/image-sync.yml
+++ b/.github/workflows/image-sync.yml
@@ -1,0 +1,54 @@
+name: Image Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_image:
+        description: 'Source container image to sync (e.g., nginx:latest, ubuntu:20.04)'
+        required: true
+      target_org:
+        description: 'Target organization in GHCR (default: current repository owner)'
+        required: false
+        default: ${{ github.repository_owner }}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image-syncer
+        run: |
+          go build -o image-syncer ./cmd/image-syncer
+
+      - name: Sync image
+        run: |
+          TARGET_ORG="${{ github.event.inputs.target_org }}"
+          if [ -z "$TARGET_ORG" ]; then
+            TARGET_ORG="${{ github.repository_owner }}"
+          fi
+          
+          ./image-syncer \
+            -source "${{ github.event.inputs.source_image }}" \
+            -target-org "$TARGET_ORG" \
+            -token "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+image-syncer
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+# IDE specific files
+.idea/
+.vscode/
+*.swp
+*.swo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1.19-alpine AS builder
+
+WORKDIR /app
+
+# Copy go.mod and go.sum
+COPY go.mod ./
+
+# Copy the source code
+COPY cmd/ ./cmd/
+COPY pkg/ ./pkg/
+
+# Build the application
+RUN go build -o image-syncer ./cmd/image-syncer
+
+# Use a smaller base image for the final image
+FROM alpine:3.17
+
+# Install Docker client
+RUN apk add --no-cache docker-cli
+
+# Copy the binary from the builder stage
+COPY --from=builder /app/image-syncer /usr/local/bin/image-syncer
+
+ENTRYPOINT ["image-syncer"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,125 @@
+# Image Syncer
+
+A tool to sync container images from any public container registry to GitHub Container Registry (ghcr.io).
+
+## Features
+
+- Sync container images from any public registry to GitHub Container Registry (ghcr.io)
+- Run as a GitHub Action with manual triggering
+- Configurable source image and target organization
+
+## How It Works
+
+The Image Syncer:
+
+1. Pulls the source container image from a public registry
+2. Tags it for GitHub Container Registry
+3. Authenticates with GitHub Container Registry
+4. Pushes the image to GitHub Container Registry
+
+## Usage as a GitHub Action
+
+### Setting Up the GitHub Action
+
+1. Add the GitHub Action workflow to your repository by creating a file at `.github/workflows/image-sync.yml`
+2. Ensure your repository has the necessary permissions to write packages
+
+### Manually Triggering the Action
+
+1. Go to your repository on GitHub
+2. Click on the "Actions" tab
+3. Select the "Image Sync" workflow from the list
+4. Click on "Run workflow"
+5. Enter the required parameters:
+   - **Source Image**: The container image to sync (e.g., `nginx:latest`, `ubuntu:20.04`)
+   - **Target Organization** (optional): The target organization in GHCR (defaults to the repository owner)
+6. Click "Run workflow"
+
+### Example Workflow File
+
+```yaml
+name: Image Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_image:
+        description: 'Source container image to sync (e.g., nginx:latest, ubuntu:20.04)'
+        required: true
+      target_org:
+        description: 'Target organization in GHCR (default: current repository owner)'
+        required: false
+        default: ${{ github.repository_owner }}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image-syncer
+        run: |
+          go build -o image-syncer ./cmd/image-syncer
+
+      - name: Sync image
+        run: |
+          TARGET_ORG="${{ github.event.inputs.target_org }}"
+          if [ -z "$TARGET_ORG" ]; then
+            TARGET_ORG="${{ github.repository_owner }}"
+          fi
+          
+          ./image-syncer \
+            -source "${{ github.event.inputs.source_image }}" \
+            -target-org "$TARGET_ORG" \
+            -token "${{ secrets.GITHUB_TOKEN }}"
+```
+
+## Running Locally
+
+### Prerequisites
+
+- Go 1.19 or later
+- Docker
+
+### Building
+
+```bash
+go build -o image-syncer ./cmd/image-syncer
+```
+
+### Running
+
+```bash
+./image-syncer \
+  -source "nginx:latest" \
+  -target-org "your-github-username" \
+  -token "your-github-token"
+```
+
+## License
+
+This project is licensed under the terms of the license included in the repository.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,57 @@
+name: 'Container Image Syncer'
+description: 'Sync container images from any public registry to GitHub Container Registry (ghcr.io)'
+author: 'ODearEvanHansen'
+branding:
+  icon: 'refresh-cw'
+  color: 'blue'
+
+inputs:
+  source_image:
+    description: 'Source container image to sync (e.g., nginx:latest, ubuntu:20.04)'
+    required: true
+  target_org:
+    description: 'Target organization in GHCR (default: current repository owner)'
+    required: false
+    default: ${{ github.repository_owner }}
+  github_token:
+    description: 'GitHub token for GHCR authentication'
+    required: true
+    default: ${{ github.token }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.19'
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+      
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github_token }}
+
+    - name: Build image-syncer
+      shell: bash
+      run: |
+        cd ${{ github.action_path }}
+        go build -o image-syncer ./cmd/image-syncer
+
+    - name: Sync image
+      shell: bash
+      run: |
+        cd ${{ github.action_path }}
+        TARGET_ORG="${{ inputs.target_org }}"
+        if [ -z "$TARGET_ORG" ]; then
+          TARGET_ORG="${{ github.repository_owner }}"
+        fi
+        
+        ./image-syncer \
+          -source "${{ inputs.source_image }}" \
+          -target-org "$TARGET_ORG" \
+          -token "${{ inputs.github_token }}"

--- a/cmd/image-syncer/main.go
+++ b/cmd/image-syncer/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/ODearEvanHansen/image-syncer/pkg/syncer"
+)
+
+func main() {
+	// Define command-line flags
+	sourceImage := flag.String("source", "", "Source container image to sync (required)")
+	targetOrg := flag.String("target-org", "", "Target organization in GHCR (required)")
+	ghcrToken := flag.String("token", "", "GitHub token for GHCR authentication (required)")
+
+	// Parse flags
+	flag.Parse()
+
+	// Validate required flags
+	if *sourceImage == "" || *targetOrg == "" || *ghcrToken == "" {
+		fmt.Println("Error: source image, target organization, and GHCR token are required")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	// Generate target image name
+	targetImage := syncer.ParseTargetImage(*sourceImage, *targetOrg)
+
+	// Create a new image syncer
+	imageSyncer := syncer.NewImageSyncer(*sourceImage, targetImage, *ghcrToken)
+
+	// Sync the image
+	fmt.Printf("Syncing image from %s to %s\n", *sourceImage, targetImage)
+	if err := imageSyncer.Sync(); err != nil {
+		fmt.Printf("Error syncing image: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Image sync completed successfully")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ODearEvanHansen/image-syncer
+
+go 1.19

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -1,0 +1,87 @@
+package syncer
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// ImageSyncer handles the syncing of container images from a source registry to GHCR
+type ImageSyncer struct {
+	SourceImage string
+	TargetImage string
+	GHCRToken   string
+}
+
+// NewImageSyncer creates a new ImageSyncer instance
+func NewImageSyncer(sourceImage, targetImage, ghcrToken string) *ImageSyncer {
+	return &ImageSyncer{
+		SourceImage: sourceImage,
+		TargetImage: targetImage,
+		GHCRToken:   ghcrToken,
+	}
+}
+
+// Sync pulls the source image and pushes it to GHCR
+func (s *ImageSyncer) Sync() error {
+	// Pull the source image
+	fmt.Printf("Pulling source image: %s\n", s.SourceImage)
+	pullCmd := exec.Command("docker", "pull", s.SourceImage)
+	pullCmd.Stdout = os.Stdout
+	pullCmd.Stderr = os.Stderr
+	if err := pullCmd.Run(); err != nil {
+		return fmt.Errorf("failed to pull source image: %w", err)
+	}
+
+	// Tag the image for GHCR
+	fmt.Printf("Tagging image for GHCR: %s\n", s.TargetImage)
+	tagCmd := exec.Command("docker", "tag", s.SourceImage, s.TargetImage)
+	tagCmd.Stdout = os.Stdout
+	tagCmd.Stderr = os.Stderr
+	if err := tagCmd.Run(); err != nil {
+		return fmt.Errorf("failed to tag image: %w", err)
+	}
+
+	// Login to GHCR
+	fmt.Println("Logging in to GHCR")
+	loginCmd := exec.Command("docker", "login", "ghcr.io", "-u", "$GITHUB_ACTOR", "--password-stdin")
+	loginCmd.Stdin = strings.NewReader(s.GHCRToken)
+	loginCmd.Stdout = os.Stdout
+	loginCmd.Stderr = os.Stderr
+	if err := loginCmd.Run(); err != nil {
+		return fmt.Errorf("failed to login to GHCR: %w", err)
+	}
+
+	// Push the image to GHCR
+	fmt.Printf("Pushing image to GHCR: %s\n", s.TargetImage)
+	pushCmd := exec.Command("docker", "push", s.TargetImage)
+	pushCmd.Stdout = os.Stdout
+	pushCmd.Stderr = os.Stderr
+	if err := pushCmd.Run(); err != nil {
+		return fmt.Errorf("failed to push image to GHCR: %w", err)
+	}
+
+	fmt.Println("Image sync completed successfully")
+	return nil
+}
+
+// ParseTargetImage generates the target image name based on the source image
+// and the target organization
+func ParseTargetImage(sourceImage, targetOrg string) string {
+	// Extract the image name and tag from the source image
+	parts := strings.Split(sourceImage, "/")
+	var imagePart string
+	if len(parts) > 1 {
+		imagePart = parts[len(parts)-1]
+	} else {
+		imagePart = sourceImage
+	}
+
+	// If the target org doesn't include ghcr.io, add it
+	if !strings.HasPrefix(targetOrg, "ghcr.io/") {
+		targetOrg = "ghcr.io/" + targetOrg
+	}
+
+	return targetOrg + "/" + imagePart
+}

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -45,7 +45,11 @@ func (s *ImageSyncer) Sync() error {
 
 	// Login to GHCR
 	fmt.Println("Logging in to GHCR")
-	loginCmd := exec.Command("docker", "login", "ghcr.io", "-u", "$GITHUB_ACTOR", "--password-stdin")
+	githubActor := os.Getenv("GITHUB_ACTOR")
+	if githubActor == "" {
+		githubActor = "github-actions"
+	}
+	loginCmd := exec.Command("docker", "login", "ghcr.io", "-u", githubActor, "--password-stdin")
 	loginCmd.Stdin = strings.NewReader(s.GHCRToken)
 	loginCmd.Stdout = os.Stdout
 	loginCmd.Stderr = os.Stderr


### PR DESCRIPTION
This PR implements a container image syncer that:

1. Syncs container images from any public registry to GitHub Container Registry (ghcr.io)
2. Runs as a GitHub Action with manual triggering
3. Allows configuring the source image and target organization via GitHub Action inputs

The implementation includes:
- Go code for the image syncer
- GitHub Action workflow for manual triggering
- Dockerfile for containerization
- Comprehensive README with usage instructions